### PR TITLE
Remove dead code path on checking default package name getter is not null

### DIFF
--- a/src/main/java/org/mybatis/scripting/freemarker/support/TemplateFilePathProvider.java
+++ b/src/main/java/org/mybatis/scripting/freemarker/support/TemplateFilePathProvider.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015-2022 the original author or authors.
+ *    Copyright 2015-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ public class TemplateFilePathProvider {
 
   private static String generateTemplatePath(Class<?> type, Method method, String databaseId) {
     Package pkg = type.getPackage();
-    String packageName = pkg == null ? "" : pkg.getName();
+    String packageName = pkg.getName();
     String className = type.getName().substring(packageName.length() + (packageName.isEmpty() ? 0 : 1));
 
     PathProviderConfig pathProviderConfig = languageDriverConfig.getTemplateFile().getPathProvider();

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2015-2024 the original author or authors.
+       Copyright 2015-2026 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.


### PR DESCRIPTION
not possible since java 9 as it always returns empty space.  We require java 11 at minimum so the path is dead code and could not be tested therefore removed as correct modern processing behaviour.  Confirmed this condition by dropping back to junit 5 and testing with java 11 on the default package in our tests.